### PR TITLE
Fixing build for macOS ventura

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /xcode/NativeTrackpad.build
 /xcode/NativeTrackpad.xcodeproj/project.xcworkspace
 /xcode/NativeTrackpad.xcodeproj/xcuserdata
+/xcode/NativeTrackpad.dylib
+/xcode/NativeTrackpad.xcodeproj/xcshareddata

--- a/README.md
+++ b/README.md
@@ -40,3 +40,30 @@ There is no special needs to configure your Trackpad in System Preferences.
 What I personaly do is set Tracking speed to maximum to have panning even faster.
 
 ![manual install](res/install.png)
+
+## Development
+
+1. Build the add-in in xcode
+2. Add the add-in at `<repo>/xcode/` to fusion360
+3. The add-in dylib isn't automatically reloaded, so changes require restarting
+   fusion360.
+4. To enable debugging fusion360 with xcode debugger, you need to strip the
+   hardened runtime code signature from the app. The actual fusion360 app that
+   is codesigned is located in a non-standard directory.
+
+  To check code signature:
+   ```
+   codesign -d -vvv ~/Library/ApplicationSupport/Autodesk/webdeploy/production/Autodesk\ Fusion\ 360.app
+   ```
+
+  To remove code signature:
+   ```
+   sudo codesign --remove-signature ~/Library/ApplicationSupport/Autodesk/webdeploy/production/Autodesk\ Fusion\ 360.app
+   ```
+
+5. Log values like so:
+
+  ```
+  std::string str = "TARGET: x: " + std::to_string(target->x()) + " y: " + std::to_string(target->y()) + " z: " + std::to_string(target->z());
+  adsk::core::Application::log(str);
+  ```

--- a/xcode/NativeTrackpad.mm
+++ b/xcode/NativeTrackpad.mm
@@ -1,6 +1,6 @@
 #include <Core/CoreAll.h>
 #include <Fusion/FusionAll.h>
-#include <CAM/CAMAll.h>
+#include <Cam/CAMAll.h>
 
 #include <Foundation/Foundation.h>
 #include <Cocoa/Cocoa.h>
@@ -11,14 +11,14 @@ using namespace adsk::core;
 using namespace adsk::fusion;
 using namespace adsk::cam;
 
-Ptr<Application> app;
-Ptr<UserInterface> ui;
+adsk::core::Ptr<Application> app;
+adsk::core::Ptr<UserInterface> ui;
 
 
 /**
  * Helper function
  */
-Ptr<Vector3D> getViewportCameraRightVector() {
+adsk::core::Ptr<Vector3D> getViewportCameraRightVector() {
     auto camera = app->activeViewport()->camera();
     
     auto right = camera->upVector();
@@ -34,7 +34,7 @@ Ptr<Vector3D> getViewportCameraRightVector() {
 /**
  * Helper function
  */
-void panViewportCameraByVector(Ptr<Vector3D> vector) {
+void panViewportCameraByVector(adsk::core::Ptr<Vector3D> vector) {
     auto camera = app->activeViewport()->camera();
     camera->isSmoothTransition(false);
     

--- a/xcode/NativeTrackpad.xcodeproj/project.pbxproj
+++ b/xcode/NativeTrackpad.xcodeproj/project.pbxproj
@@ -234,7 +234,9 @@
 		2BB196C31AD586AA00164CD3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(EFFECTIVE_PLATFORM_NAME)";
+				EXCLUDED_ARCHS = arm64;
 				EXECUTABLE_EXTENSION = dylib;
 				EXECUTABLE_PREFIX = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -260,7 +262,9 @@
 		2BB196C41AD586AA00164CD3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(EFFECTIVE_PLATFORM_NAME)";
+				EXCLUDED_ARCHS = arm64;
 				EXECUTABLE_EXTENSION = dylib;
 				EXECUTABLE_PREFIX = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";


### PR DESCRIPTION
These changes fix the build for macos Ventura 13.2, and adds some information to the readme on how to debug the dylib.